### PR TITLE
Hotfix 0.2.1

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -58,6 +58,7 @@ private fun KotlinMultiplatformExtension.setupTargets() {
     // (WASI was removed as it isn't supported by Kermit at the moment)
 
     jvm()
+    jvmToolchain(17)
 
     iosArm64() // iOS device
     iosSimulatorArm64() // iOS simulator (on Apple Silicon machine)

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "dk.anigif"
-version = "0.2.0"
+version = "0.2.1"
 val baseArtifactId = "anigif-kmp"
 
 kotlin {


### PR DESCRIPTION
Set JVM tool chain to 17, otherwise it "randomly" depended on the machine it was built on